### PR TITLE
fix convert processor

### DIFF
--- a/lib/refile/mini_magick.rb
+++ b/lib/refile/mini_magick.rb
@@ -130,7 +130,7 @@ module Refile
     # @param [String] format        the file format to convert to
     # @return [File]                the processed file
     def call(file, *args, format: nil, &block)
-      img = ::MiniMagick::Image.new(file.path)
+      img = ::MiniMagick::Image.open(file.path)
       img.format(format.to_s.downcase, nil) if format
       send(@method, img, *args, &block)
 

--- a/spec/refile/mini_magick_spec.rb
+++ b/spec/refile/mini_magick_spec.rb
@@ -5,8 +5,8 @@ require "phashion"
 ["ImageMagick", "GraphicsMagick"].each do |cli|
   RSpec.context "With #{cli}", cli: cli.downcase.to_sym do
     describe Refile::MiniMagick do
-      let(:portrait) { Tempfile.new(["portrait", ".jpg"]) }
-      let(:landscape) { Tempfile.new(["landscape", ".jpg"]) }
+      let(:portrait) { Tempfile.new("portrait") }
+      let(:landscape) { Tempfile.new("landscape") }
 
       matcher :be_similar_to do |expected|
         match do |actual|


### PR DESCRIPTION
Fixes refile/refile#316

The extensions of the temp files in the spec were removed to mimic the temp files created by `refile`.
