### PR TITLE
Feature, Add Quality Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following processing helpers are provided for Refile:
 * /attachments/:token/:backend\_name**/fit/500/500**/:id
 * /attachments/:token/:backend\_name**/fill/500/500**/:id
 * /attachments/:token/:backend\_name**/pad/500/500**/:id
+* /attachments/:token/:backend\_name**/quality/50**/:id
 * /attachments/:token/:backend\_name**/resample/500/500**/:id
 
 Refile::MiniMagick internally delegates to [ImageProcessing] dependency gem, so

--- a/lib/refile/mini_magick.rb
+++ b/lib/refile/mini_magick.rb
@@ -91,6 +91,17 @@ module Refile
       pipeline.resize_and_pad!(width, height, gravity: gravity, background: background)
     end
 
+    # Adjust the quality level of an JPEG/MIFF/PNG image to the specified
+    # quality level.
+    #
+    # @param [ImageProcesing::Pipeline] pipeline   processing pipeline to call
+    # @param [#to_s] level                         the JPEG/MIFF/PNG compression level
+    # @return [Tempfile]
+    # @see http://www.imagemagick.org/script/command-line-options.php#quality
+    def quality(pipeline, level)
+      pipeline.quality!(level)
+    end
+
     # Resample the image to fit within the specified resolution while retaining
     # the original image size.
     #
@@ -114,11 +125,13 @@ module Refile
     #
     # @param [File] file                  the file to manipulate
     # @param [String] format              the file format to convert to
+    # @param [#to_s] quality              the quality level to apply
     # @yield [MiniMagick::Tool::Convert]
     # @return [Tempfile]                  the processed file
-    def call(file, *args, format: nil, &block)
+    def call(file, *args, format: nil, quality: nil, &block)
       pipeline = ImageProcessing::MiniMagick.source(file)
       pipeline = pipeline.convert(format) if format
+      pipeline = pipeline.quality(quality) if quality
       pipeline = pipeline.custom(&block)
 
       send(@method, pipeline, *args)
@@ -126,6 +139,6 @@ module Refile
   end
 end
 
-[:fill, :fit, :limit, :pad, :convert, :resample].each do |name|
+[:fill, :fit, :limit, :pad, :convert, :quality, :resample].each do |name|
   Refile.processor(name, Refile::MiniMagick.new(name))
 end

--- a/spec/refile/mini_magick_spec.rb
+++ b/spec/refile/mini_magick_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe Refile::MiniMagick do
     FileUtils.cp(fixture_path("landscape.jpg"), landscape.path)
   end
 
+  describe '#call' do
+    it 'accepts a image format' do
+      file = Refile::MiniMagick.new(:limit)
+                               .call(portrait, "400", "400", format: 'png')
+      expect(::MiniMagick::Image.new(file.path).identify).to match(/PNG/)
+    end
+
+    it 'accepts a quality level' do
+      file = Refile::MiniMagick.new(:limit)
+                               .call(portrait, "400", "400", quality: '50')
+      details = ::MiniMagick::Image.new(file.path).identify(&:verbose)
+      expect(details).to match(/Quality: 50/)
+    end
+  end
+
   describe "#convert" do
     it "changes the image format" do
       file = Refile::MiniMagick.new(:convert).call(portrait, "png")
@@ -117,6 +132,20 @@ RSpec.describe Refile::MiniMagick do
 
     it "yields the command object" do
       expect { |b| Refile::MiniMagick.new(:pad).call(portrait, "400", "400", &b) }
+        .to yield_with_args(MiniMagick::Tool)
+    end
+  end
+
+  describe "#quality" do
+    it "reduces high quality images to low quality" do
+      file = Refile::MiniMagick.new(:quality).call(landscape, "50")
+      result = ::MiniMagick::Image.new(file.path)
+      details = ::MiniMagick::Image.new(file.path).identify(&:verbose)
+      expect(details).to match(/Quality: 50/)
+    end
+
+    it "yields the command object" do
+      expect { |b| Refile::MiniMagick.new(:quality).call(landscape, "50", &b) }
         .to yield_with_args(MiniMagick::Tool)
     end
   end


### PR DESCRIPTION
This patch exposes the `quality` method from ImageMagick.

**Processor**
A new processor was added that can be used to only apply the quality
option without doing any further converting.

**Converter Option**
A new `quality` option was also added to the `Refile::MiniMagick#call`
method. It allows to change the quality while doing other processing at
the same time.

**Specs**
The test suite has been extended to include specs for the new `quality`
converter and for the new and existing options on
`Refile::MiniMagick#call` method.

**Changes to Refile**

Those changes are backwards compatible. However, A second PR to the
refile gem itself would be needed to make the `quality` option usable.

Closes https://github.com/refile/refile-mini_magick/issues/22